### PR TITLE
Fixing warnings on deprecated methods for pandera and fico

### DIFF
--- a/src/chalet/algo/util.py
+++ b/src/chalet/algo/util.py
@@ -186,8 +186,7 @@ def separate_lazy_constraints(
     current_node = problem.getAttrib("currentnode")
     parent_node = problem.getAttrib("parentnode")
 
-    x: List = []
-    problem.getlpsol(x, None, None, None)
+    x = problem.getCallbackSolution()
     cut_count = 0
 
     candidate_vals = [x[model.getIndex(station_vars[u])] for u in candidates.index]

--- a/src/chalet/model/base_csv_file.py
+++ b/src/chalet/model/base_csv_file.py
@@ -4,7 +4,7 @@
 """Base csv file."""
 from abc import abstractmethod
 
-from pandera import DataFrameSchema
+from pandera.pandas import DataFrameSchema
 
 from chalet.model.base_file import BaseFile
 

--- a/src/chalet/model/input/arc.py
+++ b/src/chalet/model/input/arc.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Arc between two nodes in a network graph."""
-from pandera import Check, Column, DataFrameSchema
+from pandera.pandas import Check, Column, DataFrameSchema
 
 from chalet.model.base_csv_file import BaseCsvFile
 

--- a/src/chalet/model/input/node.py
+++ b/src/chalet/model/input/node.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Node in a network graph."""
-from pandera import Check, Column, DataFrameSchema
+from pandera.pandas import Check, Column, DataFrameSchema
 
 from chalet.model.base_csv_file import BaseCsvFile
 from chalet.model.input.node_type import NodeType

--- a/src/chalet/model/input/od_pair.py
+++ b/src/chalet/model/input/od_pair.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Origin Destination Pair in a network."""
-from pandera import Column, DataFrameSchema
+from pandera.pandas import Column, DataFrameSchema
 
 from chalet.model.base_csv_file import BaseCsvFile
 

--- a/src/chalet/preprocess/arcs.py
+++ b/src/chalet/preprocess/arcs.py
@@ -162,7 +162,7 @@ class PreprocessArcs(PreprocessData):
         tail_is_station = (nodes.loc[arcs[Arc.tail_id], Node.type] == NodeType.STATION).values
         head_is_site = (nodes.loc[arcs[Arc.head_id], Node.type] == NodeType.SITE).values
 
-        arcs[Arcs.fuel_time] = 0
+        arcs[Arcs.fuel_time] = 0.0
 
         def charge_time_to_station(dist):
             return recharge_time(buffer, buffer + dist / truck_range, charger_power, battery_capacity)


### PR DESCRIPTION
Fixed build warnings:
- src/chalet/preprocess/arcs.py:178: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas.
- src/chalet/algo/mip/min_cost_pairs.py:36: DeprecationWarning: Deprecated in Xpress 9.5: create linked variables by calling problem.addVariables()
- src/chalet/algo/mip/min_cost_pairs.py:101: DeprecationWarning: Deprecated in Xpress 9.5: use problem.getCallbackSolution and related functions instead
- src/chalet/algo/util.py:190: DeprecationWarning: Deprecated in Xpress 9.5: use problem.getCallbackSolution and related functions instead

Changes:
- updated pandera import interface 
- updated addVariable in min_cost 
- changed fico getlpsol interface for the CallBackSolution 
- changed dtype to float in arcs 

Testing:
- triggered e2e on test data/ compared same optimization numbers 

