### PR TITLE
Fixing unit-tests and deprecation warnings

### DIFF
--- a/src/chalet/model/base_csv_file.py
+++ b/src/chalet/model/base_csv_file.py
@@ -4,7 +4,7 @@
 """Base csv file."""
 from abc import abstractmethod
 
-from pandera import DataFrameSchema
+from pandera.pandas import DataFrameSchema
 
 from chalet.model.base_file import BaseFile
 

--- a/src/chalet/model/input/arc.py
+++ b/src/chalet/model/input/arc.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Arc between two nodes in a network graph."""
-from pandera import Check, Column, DataFrameSchema
+from pandera.pandas import Check, Column, DataFrameSchema
 
 from chalet.model.base_csv_file import BaseCsvFile
 

--- a/src/chalet/model/input/node.py
+++ b/src/chalet/model/input/node.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Node in a network graph."""
-from pandera import Check, Column, DataFrameSchema
+from pandera.pandas import Check, Column, DataFrameSchema
 
 from chalet.model.base_csv_file import BaseCsvFile
 from chalet.model.input.node_type import NodeType

--- a/src/chalet/model/input/od_pair.py
+++ b/src/chalet/model/input/od_pair.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Origin Destination Pair in a network."""
-from pandera import Column, DataFrameSchema
+from pandera.pandas import Column, DataFrameSchema
 
 from chalet.model.base_csv_file import BaseCsvFile
 

--- a/src/chalet/preprocess/arcs.py
+++ b/src/chalet/preprocess/arcs.py
@@ -162,7 +162,7 @@ class PreprocessArcs(PreprocessData):
         tail_is_station = (nodes.loc[arcs[Arc.tail_id], Node.type] == NodeType.STATION).values
         head_is_site = (nodes.loc[arcs[Arc.head_id], Node.type] == NodeType.SITE).values
 
-        arcs[Arcs.fuel_time] = 0
+        arcs[Arcs.fuel_time] = 0.0
 
         def charge_time_to_station(dist):
             return recharge_time(buffer, buffer + dist / truck_range, charger_power, battery_capacity)

--- a/src/chalet/preprocess/preprocess.py
+++ b/src/chalet/preprocess/preprocess.py
@@ -1,4 +1,5 @@
 """Preprocessing module."""
+
 import logging
 from abc import ABC, ABCMeta, abstractmethod
 

--- a/src/tests/algo/mip/test_helper.py
+++ b/src/tests/algo/mip/test_helper.py
@@ -29,7 +29,7 @@ class TestMipHelper(unittest.TestCase):
             MipData.od_pairs_feasible, NODES, SUB_GRAPHS
         )
         self.assertListEqual(indices, [0])
-        np.alltrue(candidates == [0, 1, 2])
+        np.all(candidates == [0, 1, 2])
         self.assertEqual(demand, 0)
         mock_pair_coverage.assert_called_once()
 


### PR DESCRIPTION
*Description of changes:*

Test results before:
```
FAILED src/tests/algo/mip/test_helper.py::TestMipHelper::test_get_subgraph_indices_and_candidates - AttributeError: `np.alltrue` was removed in the NumPy 2.0 release. Use `np.all` instead.
========================================================================= 1 failed, 265 passed, 18 warnings in 4.74s =========================================================================
py39: exit 1 (5.19 seconds) /Users/gilelina/Desktop/chalet-charging-location-for-electric-trucks> pytest --cov /Users/gilelina/Desktop/chalet-charging-location-for-electric-trucks/.tox/py39/lib/python3.9/site-packages/chalet --cov-config /Users/gilelina/Desktop/chalet-charging-location-for-electric-trucks/pyproject.toml --cov-append src/tests/ pid=30858
  flake8: OK (0.55=setup[0.03]+cmd[0.51] seconds)
  black: FAIL code 1 (0.33=setup[0.00]+cmd[0.33] seconds)
  isort: OK (0.25=setup[0.00]+cmd[0.24] seconds)
  mypy: OK (0.57=setup[0.00]+cmd[0.57] seconds)
  py38: SKIP (0.01 seconds)
  py39: FAIL code 1 (8.24=setup[3.05]+cmd[5.19] seconds)
  evaluation failed :( (9.96 seconds)
```
Full tox output: 
[output_before.txt](https://github.com/user-attachments/files/22188861/output_before.txt)

Test results after:
```
============================================================================== 266 passed, 15 warnings in 4.69s ==============================================================================
  flake8: OK (0.52=setup[0.03]+cmd[0.48] seconds)
  black: OK (0.31=setup[0.00]+cmd[0.31] seconds)
  isort: OK (0.25=setup[0.00]+cmd[0.24] seconds)
  mypy: OK (0.49=setup[0.00]+cmd[0.49] seconds)
  py38: SKIP (0.01 seconds)
  py39: OK (8.22=setup[3.07]+cmd[5.15] seconds)
  congratulations :) (9.81 seconds)
```
Full tox output:
[output_after.txt](https://github.com/user-attachments/files/22188874/output_after.txt)

There are some remaining warnings related to xpress version and deprecations, I am going to fix them in separate PR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
